### PR TITLE
add inline CSV load via LOAD DATA control blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The database work runs in a native binary (GraalVM), so there's **no JVM at runt
 - **Named connections** with `$ENV_VAR` password references, stored at `chmod 600`.
 - **Typed bind parameters** from a `dblite.binds.json` file — numbers, quoted strings, and raw SQL expressions.
 - **Export** the entire result set (not just the current page) to CSV or JSON.
+- **Load** a CSV into a table with a SQL\*Loader-style `LOAD DATA` block — previewed as `INSERT`s before you commit.
 - **Inspect** any page untruncated as JSON, table, or CSV.
 - **SQL autocomplete** via [blink.cmp](https://github.com/Saghen/blink.cmp) — tables, columns, and bind names from the live schema.
 - **Connection UI** — a built-in side panel, or an opt-in [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim) picker.
@@ -155,6 +156,7 @@ SQL Server connections use `encrypt=true;trustServerCertificate=true` for broad 
 | `:Dblite toggle dbout` | Show/hide the result window (query keeps running if in-flight) |
 | `:Dblite inspect [json\|table\|csv]` | Open the current page untruncated in a scratch window |
 | `:Dblite export <csv\|json> [path]` | Write the **entire** result set to a file |
+| `:Dblite load` | Load a CSV into a table from a `LOAD DATA` control block (preview, then commit) |
 
 Trailing semicolons are stripped automatically. The legacy `:DbliteRun`, `:DbliteRunAt`, and `:DbliteToggleOut` commands remain as aliases. Running from a different tab moves the dbout split to that tab.
 
@@ -209,6 +211,39 @@ The binds window is a vertical split by default; set `binds_split.style = 'float
 ```
 
 `~`, env vars, and relative paths are expanded, and missing parent directories are created. CSV is RFC-4180 escaped; JSON is pretty-printed via `jq` when available (compact fallback otherwise).
+
+</details>
+
+<details>
+<summary><b>Loading CSV data</b></summary>
+
+Write a SQL\*Loader-style control block in any buffer and run `:Dblite load` (or `:DbliteLoad`). dblite parses it, reads the CSV, and opens a **preview** of the `INSERT`s it will run — nothing touches the database until you commit:
+
+```
+LOAD DATA
+INFILE 'employees.csv'
+INTO TABLE employees
+SKIP 1
+FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
+TRAILING NULLCOLS
+( employee_id, name, department )
+```
+
+In the preview buffer, press `<CR>` to commit — the `INSERT`s run through script mode and land as a per-row OK/ERROR log in dbout — or `q` to cancel. The preview is editable SQL, so you can tweak it before committing. Keys are set by `keymaps.load`; the window style by `load_view` (`tab` | `vertical` | `horizontal` | `float`).
+
+> This is an **emulation**, not real `sqlldr` — the `dblite` binary has no Oracle client, so a practical subset of the control syntax is converted to `INSERT`s and run over your existing JDBC connection.
+
+| Control clause | Behaviour |
+|---|---|
+| `INFILE 'path'` | CSV path — relative to cwd, `~` and `$ENV_VAR` expanded (`INFILE *` unsupported) |
+| `INTO TABLE name` | Target table; optional `APPEND` (default), `REPLACE` (DELETE first), or `TRUNCATE` |
+| `SKIP n` | Skip the first `n` rows (e.g. a header) |
+| `FIELDS TERMINATED BY 'c'` | Field separator (default `,`; also `X'09'` hex, e.g. tab) |
+| `(OPTIONALLY) ENCLOSED BY 'c'` | Quote character (default `"`) |
+| `TRAILING NULLCOLS` | Pad rows with fewer fields than columns as `NULL` |
+| `( col, col, ... )` | Target columns, in file order |
+
+Values are typed best-effort: numbers unquoted, empty fields become `NULL`, everything else is single-quoted (with `''` escaping). Dates rely on Oracle's implicit NLS conversion. Per-column datatypes/transforms, positional fields, and direct-path are not supported.
 
 </details>
 
@@ -311,6 +346,7 @@ db.execute()               -- run the current buffer
 db.execute_at_cursor()     -- run the statement under the cursor
 db.toggle_dbout()          -- show/hide the result window
 db.inspect(format)         -- 'json' | 'table' | 'csv'
+db.load()                  -- preview + commit a LOAD DATA control block in the buffer
 db.toggle_binds()          -- toggle the dblite.binds.json split
 db.toggle_panel()          -- toggle the connections panel
 db.get_active_conn()       -- active connection object, or nil
@@ -362,6 +398,7 @@ require('dblite').setup({
   filetype       = '',            -- filetype for the result buffer ('' = no highlighting)
   flash_timeout  = 2000,          -- ms to hold the query highlight; 0 = hold until results
   json_view      = 'tab',         -- where inspect opens: 'tab' | 'vertical' | 'horizontal' | 'float'
+  load_view      = 'tab',         -- where the CSV-load preview opens: 'tab' | 'vertical' | 'horizontal' | 'float'
   inspect_format = 'json',        -- default inspect format: 'json' | 'table' | 'csv'
   inspect_expand_json = true,     -- json inspect: decode cell values that are themselves JSON strings
   panel = {
@@ -406,6 +443,7 @@ require('dblite').setup({
       fullscreen = '<leader>l',   -- toggle dbout fullscreen
     },
     panel = { select = '<CR>', edit = 'cw', close = 'q' },
+    load  = { commit = '<CR>', cancel = 'q' },  -- CSV-load preview buffer
   },
 })
 ```

--- a/doc/dblite.txt
+++ b/doc/dblite.txt
@@ -166,6 +166,36 @@ window was open in another tab it is closed there first.
 `max_rows` caps the number of rows returned (default 10000). Results are
 paginated in the dbout buffer at `page_size` rows per page (default 100).
 
+Loading CSV data ~					*dblite-load*
+
+Write a SQL*Loader-style control block in a buffer and run |:DbliteLoad| (or
+`:Dblite load`). dblite parses the block, reads the CSV, and opens a preview
+of the generated INSERTs; nothing runs until you commit it: >
+
+	LOAD DATA
+	INFILE 'employees.csv'
+	INTO TABLE employees
+	SKIP 1
+	FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
+	TRAILING NULLCOLS
+	( employee_id, name, department )
+<
+In the preview buffer press `<CR>` to commit (run the INSERTs through script
+mode; results appear as a per-row OK/ERROR log in the dbout) or `q` to cancel.
+The preview is editable SQL, so you can tweak it before committing. Keys are
+configurable via `keymaps.load`; the window style via `load_view`.
+
+This is an emulation, not real sqlldr (the binary has no Oracle client): a
+practical subset of the control syntax is turned into INSERTs. Supported:
+`INFILE 'path'` (relative to cwd, ~/$ENV expanded), `INTO TABLE name` with an
+optional `APPEND` (default) / `REPLACE` (DELETE first) / `TRUNCATE` mode,
+`SKIP n`, `FIELDS TERMINATED BY 'c'` (also `X'09'` hex, e.g. tab), `(OPTIONALLY)
+ENCLOSED BY 'c'` (default `"`), `TRAILING NULLCOLS`, and a `(col, ...)` list.
+Values are typed best-effort: numbers unquoted, empty fields become NULL,
+everything else is quoted. Dates rely on Oracle's implicit NLS conversion.
+Not supported: per-column datatypes/transforms, positional fields, direct
+path, and inline `BEGINDATA` (`INFILE *`).
+
 ==============================================================================
 8. RESULT BUFFER (dbout)				*dblite-dbout*
 
@@ -340,6 +370,8 @@ Unified entry point ~
 :Dblite build			Download or build the native binary.
 :Dblite inspect [fmt]		Inspect current page (json|table|csv).
 :Dblite binds			Toggle the dblite.binds.json window.
+:Dblite load			Load a CSV via a LOAD DATA control block
+				(preview, then commit). See |dblite-load|.
 
 All subcommands and connection names support <Tab> completion.
 
@@ -367,6 +399,11 @@ Individual commands ~
 							*:DbliteBuild*
 :DbliteBuild			Download a pre-built binary, or build from
 				source if none matches your platform.
+							*:DbliteLoad*
+:DbliteLoad			Load a CSV into a table from a SQL*Loader-style
+				LOAD DATA control block in the current buffer,
+				previewing the INSERTs before you commit them.
+				Accepts a range. See |dblite-load|.
 
 The unified :Dblite forms and these individual commands are equivalent;
 :DbliteRun, :DbliteRunAt, and :DbliteToggleOut are kept as aliases.

--- a/lua/dblite/config.lua
+++ b/lua/dblite/config.lua
@@ -47,6 +47,7 @@ local M = {
   },
   flash_timeout  = 2000,  -- ms to hold the query highlight before auto-clearing (0 = wait for results)
   json_view      = "tab",  -- where to open the inspector: "tab" | "vertical" | "horizontal" | "float"
+  load_view      = "tab",  -- where to open the CSV-load preview: "tab" | "vertical" | "horizontal" | "float"
   inspect_format = "json", -- default inspect format: "json" | "table" | "csv"
   inspect_expand_json = true, -- in json inspect, decode cell values that are themselves JSON strings so they nest cleanly
   style = {
@@ -83,6 +84,10 @@ local M = {
       select = "<CR>", -- activate connection under cursor
       edit   = "cw",   -- edit connection under cursor
       close  = "q",    -- close panel
+    },
+    load = {     -- keymaps active inside the CSV-load preview buffer
+      commit = "<CR>", -- run the generated INSERTs
+      cancel = "q",    -- discard the preview without running
     },
   },
 }

--- a/lua/dblite/init.lua
+++ b/lua/dblite/init.lua
@@ -3,6 +3,7 @@ local connections  = require("dblite.connections")
 local panel        = require("dblite.panel")
 local telescope    = require("dblite.telescope")
 local query_module = require("dblite.query")
+local load_mod     = require("dblite.load")
 
 local M = {}
 
@@ -1398,6 +1399,125 @@ function M.export(format, path)
     #state.rows, #state.rows == 1 and "" or "s", path), vim.log.levels.INFO)
 end
 
+-- Open a scratch buffer previewing the INSERTs a CSV load will run. The buffer
+-- is editable SQL: on commit we run whatever it currently holds (minus the
+-- comment header) through script mode, so the user can tweak before committing.
+local function open_load_preview(control, built, path)
+  local km = (config.keymaps and config.keymaps.load) or {}
+  local commit_key = km.commit or "<CR>"
+  local cancel_key = km.cancel or "q"
+
+  local lines = {}
+  local function h(s) lines[#lines + 1] = "-- " .. s end
+  h(string.format("dblite load — %s to commit, %s to cancel", commit_key, cancel_key))
+  h("source : " .. path)
+  h(string.format("target : %s   (mode=%s)", control.table, control.mode))
+  h("columns: " .. table.concat(control.columns, ", "))
+  local extra = built.skipped > 0 and string.format("  (skipped %d header row(s))", built.skipped) or ""
+  h(string.format("rows   : %d insert(s)%s", built.count, extra))
+  if #built.errors > 0 then
+    h(string.format("errors : %d row(s) not inserted —", #built.errors))
+    for _, e in ipairs(built.errors) do h("  " .. e) end
+  end
+  lines[#lines + 1] = ""
+  vim.list_extend(lines, built.statements)
+
+  local view = config.load_view or "tab"
+  local bufnr, winnr
+  if view == "float" then
+    local width  = math.floor(vim.o.columns * 0.85)
+    local height = math.floor(vim.o.lines * 0.80)
+    bufnr = vim.api.nvim_create_buf(false, true)
+    winnr = vim.api.nvim_open_win(bufnr, true, {
+      relative = "editor", style = "minimal", border = "rounded",
+      width = width, height = height,
+      row = math.floor((vim.o.lines - height) / 2),
+      col = math.floor((vim.o.columns - width) / 2),
+    })
+  else
+    local cmds = { tab = "tabnew", vertical = "botright vnew", horizontal = "botright new" }
+    vim.cmd(cmds[view] or "tabnew")
+    bufnr = vim.api.nvim_get_current_buf()
+    winnr = vim.api.nvim_get_current_win()
+  end
+
+  vim.bo[bufnr].buftype   = "nofile"
+  vim.bo[bufnr].bufhidden = "wipe"
+  vim.bo[bufnr].swapfile  = false
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+  vim.bo[bufnr].filetype  = "sql"
+
+  local function close()
+    if winnr and vim.api.nvim_win_is_valid(winnr) then
+      pcall(vim.api.nvim_win_close, winnr, true)
+    end
+  end
+
+  vim.keymap.set("n", cancel_key, close, { buffer = bufnr, silent = true, desc = "dblite: cancel load" })
+  vim.keymap.set("n", commit_key, function()
+    -- Run the buffer as it stands, dropping pure-comment lines from the header.
+    local kept = {}
+    for _, ln in ipairs(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)) do
+      if not ln:match("^%s*%-%-") then kept[#kept + 1] = ln end
+    end
+    local sql = table.concat(kept, "\n")
+    close()
+    if sql:match("%S") then execute_core(sql, true) end
+  end, { buffer = bufnr, silent = true, desc = "dblite: commit load" })
+end
+
+-- :Dblite load — parse a SQL*Loader control block in the buffer, read its CSV,
+-- and preview the generated INSERTs before committing them (script mode).
+function M.load(opts)
+  local first, last
+  if opts and opts.range and opts.range > 0 then
+    first, last = opts.line1, opts.line2
+  else
+    first, last = 1, vim.api.nvim_buf_line_count(0)
+  end
+  local text = table.concat(vim.api.nvim_buf_get_lines(0, first - 1, last, false), "\n")
+
+  local control, perr = load_mod.parse(text)
+  if not control then
+    vim.notify("dblite: " .. perr, vim.log.levels.ERROR)
+    return
+  end
+
+  if vim.fn.executable(config.binary) ~= 1 then
+    vim.notify("dblite: binary not found — run :DbliteBuild", vim.log.levels.ERROR)
+    return
+  end
+  if not state.active_conn then
+    vim.notify("dblite: no active connection — use :DbliteUseConn <name>", vim.log.levels.ERROR)
+    return
+  end
+
+  -- Resolve INFILE relative to cwd, expanding ~ and $ENV_VAR (as export does).
+  local path = vim.fn.fnamemodify(vim.fn.expand(expand_env(control.infile)), ":p")
+  if vim.fn.filereadable(path) ~= 1 then
+    vim.notify("dblite: INFILE not readable: " .. path, vim.log.levels.ERROR)
+    return
+  end
+
+  local records, rerr = load_mod.read_csv(path, control.sep, control.enclosed)
+  if not records then
+    vim.notify("dblite: " .. rerr, vim.log.levels.ERROR)
+    return
+  end
+
+  local built = load_mod.build(control, records)
+  if built.count == 0 then
+    local msg = "dblite: nothing to load from " .. path
+    if #built.errors > 0 then msg = msg .. " — " .. built.errors[1] end
+    vim.notify(msg, vim.log.levels.WARN)
+    return
+  end
+
+  open_load_preview(control, built, path)
+end
+
+vim.api.nvim_create_user_command("DbliteLoad", M.load, { range = true })
+
 local _binds_win = nil
 
 local function ensure_binds_file()
@@ -1536,6 +1656,7 @@ do
       M.export(a[2], path)
     end,
     binds         = function() M.edit_binds() end,
+    load          = function() M.load() end,
   }
 
   local function complete(arg_lead, cmd_line)
@@ -1543,7 +1664,7 @@ do
     local n = #tokens
     if n == 2 then
       return vim.tbl_filter(function(k) return k:sub(1, #arg_lead) == arg_lead end,
-        { "run", "toggle", "conn", "build", "inspect", "export", "binds" })
+        { "run", "toggle", "conn", "build", "inspect", "export", "binds", "load" })
     elseif n == 3 then
       local sub = tokens[2]
       local opts = {

--- a/lua/dblite/load.lua
+++ b/lua/dblite/load.lua
@@ -1,0 +1,244 @@
+-- dblite.load — inline SQL*Loader-style CSV loading.
+--
+-- The dblite binary is pure JDBC with no Oracle client, so this does NOT shell
+-- out to real sqlldr. It parses a practical subset of the control-file syntax,
+-- reads the referenced CSV, and turns each row into an INSERT statement. The
+-- caller (init.lua) previews the generated SQL and runs it through the existing
+-- script-mode runner once the user commits.
+--
+-- This module is pure (no vim UI) so it can be unit-tested headlessly.
+
+local M = {}
+
+-- Build a case-insensitive Lua pattern from a literal keyword.
+local function ci(word)
+  return (word:gsub("%a", function(c) return "[" .. c:lower() .. c:upper() .. "]" end))
+end
+
+-- Whole-word (case-insensitive) presence test.
+local function has_word(text, w)
+  return text:match("%f[%a]" .. ci(w) .. "%f[%A]") ~= nil
+end
+
+-- Strip `-- ...` line comments, respecting single/double quoted values so a
+-- separator like `TERMINATED BY '--'` is left intact.
+local function strip_comments(text)
+  local out = {}
+  for line in (text .. "\n"):gmatch("(.-)\n") do
+    local res, i, n, q = {}, 1, #line, nil
+    while i <= n do
+      local c = line:sub(i, i)
+      if q then
+        res[#res + 1] = c
+        if c == q then q = nil end
+        i = i + 1
+      elseif c == "'" or c == '"' then
+        q = c; res[#res + 1] = c; i = i + 1
+      elseif c == "-" and line:sub(i + 1, i + 1) == "-" then
+        break -- rest of the line is a comment
+      else
+        res[#res + 1] = c; i = i + 1
+      end
+    end
+    out[#out + 1] = table.concat(res)
+  end
+  return table.concat(out, "\n")
+end
+
+-- Split a comma-separated string at top level (commas inside parens are kept),
+-- so a column spec like `amount DECIMAL EXTERNAL(9,2)` isn't split mid-type.
+local function split_top(s)
+  local parts, cur, depth = {}, {}, 0
+  for i = 1, #s do
+    local c = s:sub(i, i)
+    if c == "(" then depth = depth + 1; cur[#cur + 1] = c
+    elseif c == ")" then depth = depth - 1; cur[#cur + 1] = c
+    elseif c == "," and depth == 0 then
+      parts[#parts + 1] = table.concat(cur); cur = {}
+    else
+      cur[#cur + 1] = c
+    end
+  end
+  parts[#parts + 1] = table.concat(cur)
+  return parts
+end
+
+-- Parse a SQL*Loader control block into a control table, or nil + error.
+-- Returns: { infile, table, mode, skip, sep, enclosed, trailing, columns = {...} }
+function M.parse(text)
+  text = strip_comments(text or "")
+
+  if not text:match("^%s*" .. ci("LOAD") .. "%s+" .. ci("DATA")) then
+    return nil, "not a LOAD DATA control block (must start with 'LOAD DATA')"
+  end
+
+  -- INFILE: quoted path, or a bareword (e.g. INFILE *)
+  local infile = text:match(ci("INFILE") .. "%s*'([^']*)'")
+    or text:match(ci("INFILE") .. '%s*"([^"]*)"')
+    or text:match(ci("INFILE") .. "%s+(%S+)")
+  if not infile then return nil, "INFILE clause is required" end
+  if infile == "*" then
+    return nil, "INFILE * (inline BEGINDATA) is not supported — point INFILE at a file"
+  end
+
+  local table_name = text:match(ci("INTO") .. "%s+" .. ci("TABLE") .. "%s+([%w_%.\"$#]+)")
+  if not table_name then return nil, "INTO TABLE <name> clause is required" end
+
+  local mode = "append"
+  if has_word(text, "TRUNCATE") then mode = "truncate"
+  elseif has_word(text, "REPLACE") then mode = "replace"
+  elseif has_word(text, "INSERT") then mode = "insert"
+  end
+
+  local skip = tonumber(text:match(ci("SKIP") .. "%s+(%d+)")) or 0
+
+  -- FIELDS TERMINATED BY — literal quoted char, or X'hh' hex (e.g. tab = X'09')
+  local sep = text:match(ci("TERMINATED") .. "%s+" .. ci("BY") .. "%s*'([^']*)'")
+    or text:match(ci("TERMINATED") .. "%s+" .. ci("BY") .. '%s*"([^"]*)"')
+  local hexsep = text:match(ci("TERMINATED") .. "%s+" .. ci("BY") .. "%s*[Xx]'(%x%x)'")
+  if hexsep then sep = string.char(tonumber(hexsep, 16)) end
+  if not sep or sep == "" then sep = "," end
+
+  -- (OPTIONALLY) ENCLOSED BY — defaults to " since this is CSV-focused
+  local enclosed = text:match(ci("ENCLOSED") .. "%s+" .. ci("BY") .. "%s*'([^']*)'")
+    or text:match(ci("ENCLOSED") .. "%s+" .. ci("BY") .. '%s*"([^"]*)"')
+    or '"'
+
+  local trailing = text:match(ci("TRAILING") .. "%s+" .. ci("NULLCOLS")) ~= nil
+
+  -- Column list: first balanced (...) group. Take the leading identifier of
+  -- each entry; any trailing per-column datatype/transform is ignored.
+  local paren = text:match("%b()")
+  if not paren then return nil, "column list ( col1, col2, ... ) is required" end
+  local columns = {}
+  for _, entry in ipairs(split_top(paren:sub(2, -2))) do
+    local name = entry:match("^%s*([%w_%.\"$#]+)")
+    if name then columns[#columns + 1] = name end
+  end
+  if #columns == 0 then return nil, "no columns found in the column list" end
+
+  return {
+    infile   = infile,
+    table    = table_name,
+    mode     = mode,
+    skip     = skip,
+    sep      = sep,
+    enclosed = enclosed,
+    trailing = trailing,
+    columns  = columns,
+  }
+end
+
+-- Read a delimited file into a list of records (each a list of field strings).
+-- RFC-4180-ish: doubled enclosure = literal, quoted fields may contain the
+-- separator and newlines, \r\n and \n both terminate records. Blank lines are
+-- skipped. Assumes a single-character separator/enclosure.
+function M.read_csv(path, sep, enclosed)
+  local f, oerr = io.open(path, "rb")
+  if not f then return nil, "cannot read " .. path .. ": " .. tostring(oerr) end
+  local data = f:read("*a") or ""
+  f:close()
+
+  local sepc = (sep and sep ~= "") and sep:sub(1, 1) or ","
+  local enc = (enclosed and enclosed ~= "") and enclosed:sub(1, 1) or nil
+
+  local records, row, field = {}, {}, {}
+  local inq, i, n = false, 1, #data
+
+  local function push_field() row[#row + 1] = table.concat(field); field = {} end
+  local function push_row()
+    push_field()
+    if not (#row == 1 and row[1] == "") then records[#records + 1] = row end
+    row = {}
+  end
+
+  while i <= n do
+    local c = data:sub(i, i)
+    if inq then
+      if enc and c == enc then
+        if data:sub(i + 1, i + 1) == enc then
+          field[#field + 1] = enc; i = i + 2
+        else
+          inq = false; i = i + 1
+        end
+      else
+        field[#field + 1] = c; i = i + 1
+      end
+    elseif enc and c == enc and #field == 0 then
+      inq = true; i = i + 1 -- opening quote only at field start
+    elseif c == sepc then
+      push_field(); i = i + 1
+    elseif c == "\r" then
+      i = i + 1
+    elseif c == "\n" then
+      push_row(); i = i + 1
+    else
+      field[#field + 1] = c; i = i + 1
+    end
+  end
+  if #field > 0 or #row > 0 then push_row() end
+
+  return records
+end
+
+-- Is `s` a plain numeric literal safe to emit unquoted? Leading-zero integers
+-- (e.g. "007") stay quoted so zip-code-like strings keep their zeros.
+local function is_number(s)
+  s = s:match("^%s*(.-)%s*$")
+  if s == "" or s:match("^[-+]?0%d") then return false end
+  return s:match("^[-+]?%d+$") ~= nil
+    or s:match("^[-+]?%d*%.%d+$") ~= nil
+    or s:match("^[-+]?%d+%.%d*$") ~= nil
+end
+
+-- Format one CSV field as a SQL value: empty/nil → NULL, numeric → literal,
+-- else single-quoted with '' escaping.
+local function format_value(v)
+  if v == nil or v == "" then return "NULL" end
+  if is_number(v) then return (v:gsub("%s", "")) end
+  return "'" .. v:gsub("'", "''") .. "'"
+end
+
+-- Build INSERT statements from parsed control + CSV records.
+-- Returns { sql, statements = {...}, count, skipped, errors = {...} }.
+function M.build(control, records)
+  local cols    = control.columns
+  local ncols   = #cols
+  local collist = table.concat(cols, ", ")
+  local stmts, errors = {}, {}
+
+  if control.mode == "truncate" then
+    stmts[#stmts + 1] = "TRUNCATE TABLE " .. control.table .. ";"
+  elseif control.mode == "replace" then
+    stmts[#stmts + 1] = "DELETE FROM " .. control.table .. ";"
+  end
+
+  local skip    = control.skip or 0
+  local skipped = math.min(skip, #records)
+  local count   = 0
+
+  for ri = skip + 1, #records do
+    local rec = records[ri]
+    if #rec < ncols and not control.trailing then
+      errors[#errors + 1] = string.format(
+        "row %d: %d field(s) for %d column(s) — add TRAILING NULLCOLS to pad",
+        ri, #rec, ncols)
+    else
+      local vals = {}
+      for ci_ = 1, ncols do vals[ci_] = format_value(rec[ci_]) end
+      stmts[#stmts + 1] = string.format("INSERT INTO %s (%s) VALUES (%s);",
+        control.table, collist, table.concat(vals, ", "))
+      count = count + 1
+    end
+  end
+
+  return {
+    sql        = table.concat(stmts, "\n"),
+    statements = stmts,
+    count      = count,
+    skipped    = skipped,
+    errors     = errors,
+  }
+end
+
+return M


### PR DESCRIPTION
Parse a practical subset of SQL*Loader control-file syntax in Lua, read the referenced CSV, and preview the generated INSERTs before committing them through the existing script-mode runner. No Java/native binary changes.

- lua/dblite/load.lua: pure parse/read_csv/build (unit-testable, no vim UI)
- init.lua: M.load + preview buffer, :DbliteLoad, :Dblite load dispatch, db.load()
- config.lua: load_view + keymaps.load
- README + doc: new "Loading CSV data" section